### PR TITLE
Feat/fcm config

### DIFF
--- a/frontend/firebase-messaging-sw.js
+++ b/frontend/firebase-messaging-sw.js
@@ -16,3 +16,16 @@ const firebaseConfig = {
 // Initialize Firebase
 firebase.initializeApp(firebaseConfig);
 const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  console.log('[firebase-messaging-sw.js] Received background message ', payload);
+  // Customize notification here
+  const notificationTitle = payload.notification.title || payload.data.title;
+  const notificationOptions = {
+    body: payload.notification.body || payload.data.body,
+    icon: '/images/notes-logo.jpg',
+  };
+
+  self.registration.showNotification(notificationTitle,
+    notificationOptions);
+});

--- a/frontend/firebase-messaging-sw.js
+++ b/frontend/firebase-messaging-sw.js
@@ -1,0 +1,18 @@
+importScripts("https://www.gstatic.com/firebasejs/10.11.1/firebase-app-compat.js")
+importScripts("https://www.gstatic.com/firebasejs/10.11.1/firebase-messaging-compat.js")
+
+// Your web app's Firebase configuration
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+const firebaseConfig = {
+  apiKey: "AIzaSyDi_Ku4d07op7w8v4Nh8VdPEQ72g-iREC8",
+  authDomain: "pwa-g7.firebaseapp.com",
+  projectId: "pwa-g7",
+  storageBucket: "pwa-g7.appspot.com",
+  messagingSenderId: "12229005519",
+  appId: "1:12229005519:web:a2e6761d10bca20e3167ba",
+  measurementId: "G-JPDQW9S45S"
+};
+
+// Initialize Firebase
+firebase.initializeApp(firebaseConfig);
+const messaging = firebase.messaging();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,71 @@
             <p class="text-center">Escribe el nombre de un <i class="blue">Cuaderno de Notas</i> nuevo o ya existente</p>
         </div>
     </main>
-    <script src="scripts/app.js"></script>
+    <script type="module" src="scripts/app.js"></script>
+    <script>
+        function requestPermission() {
+            console.log('Requesting permission...');
+            Notification.requestPermission().then((permission) => {
+                if (permission === 'granted') {
+                    console.log('Notification permission granted.');
+                } else {
+                    console.log('Unable to get permission to notify.');
+                }
+            });
+        }
+        requestPermission();
+        if ('serviceWorker' in navigator) {
+            // window.addEventListener('load', () => {
+                navigator.serviceWorker.register('firebase-messaging-sw.js')
+                    .then(reg => {
+                        console.log('Firebase service worker registered.', reg);
+                    });
+            // });
+        }
+    </script>
+    <script type="module">
+        // Import the functions you need from the SDKs you need
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-app.js";
+        import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-analytics.js";
+        import {
+            getMessaging,
+            getToken,
+            onMessage,
+        } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-messaging.js";
+      
+        // Your web app's Firebase configuration
+        // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+        const firebaseConfig = {
+          apiKey: "AIzaSyDi_Ku4d07op7w8v4Nh8VdPEQ72g-iREC8",
+          authDomain: "pwa-g7.firebaseapp.com",
+          projectId: "pwa-g7",
+          storageBucket: "pwa-g7.appspot.com",
+          messagingSenderId: "12229005519",
+          appId: "1:12229005519:web:a2e6761d10bca20e3167ba",
+          measurementId: "G-JPDQW9S45S"
+        };
+      
+        // Initialize Firebase
+        const app = initializeApp(firebaseConfig);
+        const analytics = getAnalytics(app);
+        const messaging = getMessaging(app);
+        getToken(messaging, {
+            vapidKey: 
+                "BO4ruaq8L9n0N2HksdkvZ9jSO9OGFOUl6xQeVsrCpez8Ud_ZLyy-WMUWnU5GAVKSicwXOqkCafZkLP_gmPBT4b8"
+        })
+        .then((currentToken) => {
+            if (currentToken) {
+                console.log("current token for client: ", currentToken);
+            } else {
+                // Show permission request UI
+                console.log(
+                    "No registration token available. Request permission to generate one."
+                );
+            }
+        })
+        .catch((err) => {
+            console.log("An error occurred while retrieving token. ", err);
+        });
+    </script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,27 +22,6 @@
         </div>
     </main>
     <script type="module" src="scripts/app.js"></script>
-    <!-- <script>
-        function requestPermission() {
-            console.log('Requesting permission...');
-            Notification.requestPermission().then((permission) => {
-                if (permission === 'granted') {
-                    console.log('Notification permission granted.');
-                } else {
-                    console.log('Unable to get permission to notify.');
-                }
-            });
-        }
-        requestPermission();
-        if ('serviceWorker' in navigator) {
-            // window.addEventListener('load', () => {
-                navigator.serviceWorker.register('firebase-messaging-sw.js')
-                    .then(reg => {
-                        console.log('Firebase service worker registered.', reg);
-                    });
-            // });
-        }
-    </script> -->
     <script type="module" src="scripts/firebaseConfig.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
         </div>
     </main>
     <script type="module" src="scripts/app.js"></script>
-    <script>
+    <!-- <script>
         function requestPermission() {
             console.log('Requesting permission...');
             Notification.requestPermission().then((permission) => {
@@ -42,50 +42,7 @@
                     });
             // });
         }
-    </script>
-    <script type="module">
-        // Import the functions you need from the SDKs you need
-        import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-app.js";
-        import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-analytics.js";
-        import {
-            getMessaging,
-            getToken,
-            onMessage,
-        } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-messaging.js";
-      
-        // Your web app's Firebase configuration
-        // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-        const firebaseConfig = {
-          apiKey: "AIzaSyDi_Ku4d07op7w8v4Nh8VdPEQ72g-iREC8",
-          authDomain: "pwa-g7.firebaseapp.com",
-          projectId: "pwa-g7",
-          storageBucket: "pwa-g7.appspot.com",
-          messagingSenderId: "12229005519",
-          appId: "1:12229005519:web:a2e6761d10bca20e3167ba",
-          measurementId: "G-JPDQW9S45S"
-        };
-      
-        // Initialize Firebase
-        const app = initializeApp(firebaseConfig);
-        const analytics = getAnalytics(app);
-        const messaging = getMessaging(app);
-        getToken(messaging, {
-            vapidKey: 
-                "BO4ruaq8L9n0N2HksdkvZ9jSO9OGFOUl6xQeVsrCpez8Ud_ZLyy-WMUWnU5GAVKSicwXOqkCafZkLP_gmPBT4b8"
-        })
-        .then((currentToken) => {
-            if (currentToken) {
-                console.log("current token for client: ", currentToken);
-            } else {
-                // Show permission request UI
-                console.log(
-                    "No registration token available. Request permission to generate one."
-                );
-            }
-        })
-        .catch((err) => {
-            console.log("An error occurred while retrieving token. ", err);
-        });
-    </script>
+    </script> -->
+    <script type="module" src="scripts/firebaseConfig.js"></script>
 </body>
 </html>

--- a/frontend/scripts/firebaseConfig.js
+++ b/frontend/scripts/firebaseConfig.js
@@ -20,7 +20,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const messaging = getMessaging(app);
-console.log(messaging)
 
 function requestPermission() {
   console.log('Requesting permission...');
@@ -51,3 +50,11 @@ getToken(messaging, {
   .catch((err) => {
       console.log("An error occurred while retrieving token. ", err);
   });
+
+onMessage(messaging, (payload) => {
+    console.log('Message received. ', payload);
+    const notificationBody = payload.notification.body;
+
+    // TODO: replace this with a toast in the UI
+    alert(notificationBody)
+});

--- a/frontend/scripts/firebaseConfig.js
+++ b/frontend/scripts/firebaseConfig.js
@@ -1,0 +1,54 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-app.js";
+import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-analytics.js";
+import {
+    getMessaging,
+    getToken,
+    onMessage,
+} from "https://www.gstatic.com/firebasejs/10.11.1/firebase-messaging.js";
+
+// Your web app's Firebase configuration
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+const firebaseConfig = {
+  apiKey: "AIzaSyDi_Ku4d07op7w8v4Nh8VdPEQ72g-iREC8",
+  authDomain: "pwa-g7.firebaseapp.com",
+  projectId: "pwa-g7",
+  storageBucket: "pwa-g7.appspot.com",
+  messagingSenderId: "12229005519",
+  appId: "1:12229005519:web:a2e6761d10bca20e3167ba",
+  measurementId: "G-JPDQW9S45S"
+};
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);
+const messaging = getMessaging(app);
+
+function requestPermission() {
+  console.log('Requesting permission...');
+  Notification.requestPermission().then((permission) => {
+      if (permission === 'granted') {
+          console.log('Notification permission granted.');
+      } else {
+          console.log('Unable to get permission to notify.');
+      }
+  });
+}
+requestPermission();
+
+getToken(messaging, {
+    vapidKey: 
+        "BO4ruaq8L9n0N2HksdkvZ9jSO9OGFOUl6xQeVsrCpez8Ud_ZLyy-WMUWnU5GAVKSicwXOqkCafZkLP_gmPBT4b8"
+})
+  .then((currentToken) => {
+    if (currentToken) {
+        console.log("current token for client: ", currentToken);
+    } else {
+        // Show permission request UI
+        console.log(
+            "No registration token available. Request permission to generate one."
+        );
+    }
+  })
+  .catch((err) => {
+      console.log("An error occurred while retrieving token. ", err);
+  });

--- a/frontend/scripts/firebaseConfig.js
+++ b/frontend/scripts/firebaseConfig.js
@@ -1,5 +1,4 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-app.js";
-import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.11.1/firebase-analytics.js";
 import {
     getMessaging,
     getToken,
@@ -20,8 +19,8 @@ const firebaseConfig = {
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
 const messaging = getMessaging(app);
+console.log(messaging)
 
 function requestPermission() {
   console.log('Requesting permission...');


### PR DESCRIPTION
Add configuration for notifications using Firebase Cloud Messaging (FCM). Now the app is able to:

- Get notifications on Foreground using alerts
- Get notifications on Background with some styles

In the future we have to replace alerts in the foreground with toast in the UI.

One minor detail is when you send a notifications with the campaigns section on the Firebase console. This always push a notification with the attribute `notification` on the payload, which triggers the default display on background. This happens because the SDK always handles the notifications on background that have that attribute. To bypass this, we have to send notifications with the `data` attribute from the server to Firebase.